### PR TITLE
Changed A key behavior

### DIFF
--- a/switch/source/main.cpp
+++ b/switch/source/main.cpp
@@ -80,8 +80,8 @@ int main(int argc, char** argv)
             }
         }
 
-        if (kdown & KEY_A ||
-            (hidKeysDown(CONTROLLER_P1_AUTO) & KEY_TOUCH &&
+		// Handle touching the backup scrollbox
+        if ((hidKeysDown(CONTROLLER_P1_AUTO) & KEY_TOUCH &&
             (int)touch.px > 540 &&
             (int)touch.px < 1046 &&
             (int)touch.py > 462 &&
@@ -90,6 +90,32 @@ int main(int argc, char** argv)
             Gui::backupScroll(true);
             Gui::updateButtonsColor();
             Gui::entryType(CELLS);
+        }
+
+		// Handle pressing A
+		// Backup list active: Backup/Restore
+		// Backup list inactive: Activate backup list
+        if (kdown & KEY_A)
+        {
+			// If backup list is active...
+			if (Gui::backupScroll())
+			{
+				// If the "New..." entry is selected...
+				if (0 == Gui::index(CELLS))
+				{
+					io::backup(Gui::index(TITLES), g_currentUId);
+				}
+				else
+				{
+					io::restore(Gui::index(TITLES), g_currentUId);
+				}
+			}
+			else
+			{
+				Gui::backupScroll(true);
+				Gui::updateButtonsColor();
+				Gui::entryType(CELLS);
+			}
         }
         
         if (kdown & KEY_B ||


### PR DESCRIPTION
Split the handling of touching the backup list and pressing the A button into two separate decisions. Also changed the A button to select items in the backup list. Selecting "New..." (index 0) performs a backup. Selecting a backup restores the backup.